### PR TITLE
chore(rubocop): remove warning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,3 @@ Metrics/LineLength:
 Style/FileName:
   Exclude:
     - exe/*
-
-Style/RegexpLiteral:
-  MaxSlashes: 0


### PR DESCRIPTION
unrecognized parameter