### PR TITLE
Convert non UTF-8 string to avoid invalid UTF-8 sequence errors

### DIFF
--- a/lib/git_diff_parser/patches.rb
+++ b/lib/git_diff_parser/patches.rb
@@ -18,7 +18,7 @@ module GitDiffParser
       line_count = lines.count
       parsed = new
       lines.each_with_index do |line, count|
-        case line.chomp
+        case parsed.scrub_string(line.chomp)
         when /^diff/
           unless patch.empty?
             parsed << Patch.new(patch.join("\n") + "\n", file: file_name)
@@ -40,6 +40,15 @@ module GitDiffParser
         end
       end
       parsed
+    end
+
+    # @return [String]
+    def scrub_string(line)
+      if RUBY_VERSION >= '2.1'
+        line.scrub
+      else
+        line.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+      end
     end
 
     # @return [Patches<Patch>]

--- a/spec/git_diff_parser/patches_spec.rb
+++ b/spec/git_diff_parser/patches_spec.rb
@@ -11,6 +11,11 @@ module GitDiffParser
       let(:body2) { File.read('spec/support/fixtures/file2.diff') }
       let(:file3) { 'lib/saddler/reporter/github/support.rb' }
       let(:body3) { File.read('spec/support/fixtures/file3.diff') }
+
+      let(:sjis_file) { 'spec/support/fixtures/sjis.csv' }
+      let(:sjis_diff) { sjis_file.gsub(/\.csv\z/, '.diff') }
+      let(:sjis_body) { File.read(sjis_diff) }
+
       it 'returns parsed patches' do
         diff_body = File.read('spec/support/fixtures/d1bd180-c27866c.diff')
         patches = Patches.parse(diff_body)
@@ -24,6 +29,12 @@ module GitDiffParser
         expect(patches[2].body).to eq body2
         expect(patches[3].file).to eq file3
         expect(patches[3].body).to eq body3
+      end
+
+      it 'handles non UTF-8 encoding characters' do
+        patches = nil
+        expect { patches = Patches.parse(sjis_body) }.not_to raise_error
+        expect(patches[0].file).to eq sjis_file
       end
     end
   end

--- a/spec/support/fixtures/sjis.csv
+++ b/spec/support/fixtures/sjis.csv
@@ -1,0 +1,1 @@
+‡M	abcdefg

--- a/spec/support/fixtures/sjis.diff
+++ b/spec/support/fixtures/sjis.diff
@@ -1,0 +1,8 @@
+diff --git a/spec/support/fixtures/sjis.csv b/spec/support/fixtures/sjis.csv
+new file mode 100644
+index 0000000..4c19aee
+--- /dev/null
++++ b/spec/support/fixtures/sjis.csv
+@@ -0,0 +1 @@
++�M	abcdefg
+\ No newline at end of file


### PR DESCRIPTION
A simple workaround to for #91. 

To remove invalid byte sequences, I used `String#scrub` when Ruby 2.1 or higher is available. For older versions of Ruby, I chose to the workaround suggested via a blog post in the issue #91.

This PR isn't perfect because `scrub_string` method just remove invalid sequences. But I guess supporting complete encoding conversion for each line will require much effort to accomplish. If we can assume this gem only handles UTF-8 characters, I think this PR would be enough.