### PR TITLE
Fix how line numbers are counted in Patch#removed_lines

### DIFF
--- a/lib/git_diff_parser/patch.rb
+++ b/lib/git_diff_parser/patch.rb
@@ -92,6 +92,7 @@ module GitDiffParser
             patch_position: patch_position
           )
           lines << line
+        when NOT_REMOVED_LINE
           line_number += 1
         end
 

--- a/lib/git_diff_parser/patch.rb
+++ b/lib/git_diff_parser/patch.rb
@@ -1,7 +1,7 @@
 module GitDiffParser
   # Parsed patch
   class Patch
-    RANGE_INFORMATION_LINE = /^@@ .+\+(?<line_number>\d+),/
+    RANGE_INFORMATION_LINE = /^@@ -(?<old_line_number>\d+),.+\+(?<line_number>\d+),/
     MODIFIED_LINE = /^\+(?!\+|\+)/
     REMOVED_LINE = /^[-]/
     NOT_REMOVED_LINE = /^[^-]/
@@ -84,7 +84,7 @@ module GitDiffParser
       lines.each_with_index.inject([]) do |lines, (content, patch_position)|
         case content
         when RANGE_INFORMATION_LINE
-          line_number = Regexp.last_match[:line_number].to_i
+          line_number = Regexp.last_match[:old_line_number].to_i
         when REMOVED_LINE
           line = Line.new(
             content: content,
@@ -92,6 +92,7 @@ module GitDiffParser
             patch_position: patch_position
           )
           lines << line
+          line_number += 1
         when NOT_REMOVED_LINE
           line_number += 1
         end

--- a/spec/git_diff_parser/patch_spec.rb
+++ b/spec/git_diff_parser/patch_spec.rb
@@ -27,7 +27,7 @@ module GitDiffParser
         patch = Patch.new(patch_body)
 
         expect(patch.removed_lines.size).to eq(7)
-        expect(patch.removed_lines.map(&:number)).to eq [14, 39, 39, 39, 39, 39, 54]
+        expect(patch.removed_lines.map(&:number)).to eq [14, 38, 39, 40, 41, 42, 58]
         expect(patch.removed_lines.map(&:patch_position)).to eq [4, 21, 22, 23, 24, 25, 36]
       end
 

--- a/spec/git_diff_parser/patch_spec.rb
+++ b/spec/git_diff_parser/patch_spec.rb
@@ -27,7 +27,7 @@ module GitDiffParser
         patch = Patch.new(patch_body)
 
         expect(patch.removed_lines.size).to eq(7)
-        expect(patch.removed_lines.map(&:number)).to eq [11, 36, 37, 38, 39, 40, 48]
+        expect(patch.removed_lines.map(&:number)).to eq [14, 39, 39, 39, 39, 39, 54]
         expect(patch.removed_lines.map(&:patch_position)).to eq [4, 21, 22, 23, 24, 25, 36]
       end
 


### PR DESCRIPTION
Non removed lines should be counted towards the line number exclusively, test was simply incorrect previously. Manually checked against the diff to confirm this.